### PR TITLE
Fix/Allow transparency in globe texture

### DIFF
--- a/src/layers/globe.js
+++ b/src/layers/globe.js
@@ -47,7 +47,7 @@ export default Kapsule({
   stateInit: () => {
     // create globe
     const globeGeometry = new THREE.SphereGeometry(GLOBE_RADIUS, 75, 75);
-    const globeObj = new THREE.Mesh(globeGeometry, new THREE.MeshPhongMaterial({ color: 0x000000 }));
+    const globeObj = new THREE.Mesh(globeGeometry, new THREE.MeshPhongMaterial({ color: 0x000000, transparent = true }));
     globeObj.rotation.y = -Math.PI / 2; // face prime meridian along Z axis
     globeObj.__globeObjType = 'globe'; // Add object type
 


### PR DESCRIPTION
This small fix allows setting a png image with transparency to the `globeImageUrl`, getting the following effect:

<img width="1080" alt="Screen Shot 2019-11-09 at 12 09 18 AM" src="https://user-images.githubusercontent.com/48455996/68523977-fb67a100-0285-11ea-83d6-53afbb0af343.png">

**Note**: Not sure about the contribution process so feel free to let me know what is the next step so the fix can be approved.