### PR TITLE
Hold initial render until globe texture loads

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ new ThreeGlobe({ configOptions })
 
 | Config options | Description | Default |
 | --- | --- | :--: |
+| <b>waitForGlobeReady</b>: <i>boolean</i> | Whether to wait until the globe wrapping image has been fully loaded before rendering the globe or any of the data layers. | `true` |
 | <b>animateIn</b>: <i>boolean</i> | Whether to animate the globe initialization, by scaling and rotating the globe into its inital position. | `true` |
 
 ### Globe Layer

--- a/src/globe-kapsule.js
+++ b/src/globe-kapsule.js
@@ -252,20 +252,18 @@ export default Kapsule({
       state.scene.visible = false; // hide before animation
     }
 
-    // run tween updates
-    (function onFrame() {
-      requestAnimationFrame(onFrame);
-      TWEEN.update();
-    })(); // IIFE
-  },
+    state.globeLayer.onGlobeReady(() => {
+      state.scene.visible = true;
 
-  update(state) {
-    if (state.animateIn) {
+      if (!state.animateIn) {
+        return;
+      }
+
+      // Animate build-in just once
+      state.animateIn = false;
+      state.scene.scale.set(1e-6, 1e-6, 1e-6)
+
       setTimeout(() => {
-        // Animate build-in just once
-        state.animateIn = false;
-        state.scene.visible = true;
-
         new TWEEN.Tween({k: 1e-6})
           .to({k: 1}, 600)
           .easing(TWEEN.Easing.Quadratic.Out)
@@ -278,7 +276,13 @@ export default Kapsule({
           .easing(TWEEN.Easing.Quintic.Out)
           .onUpdate(({ rot }) => state.scene.setRotationFromAxisAngle(rotAxis, rot))
           .start();
-      }, 600); // delay animation slightly to load globe texture
-    }
+      }, 600)
+    });
+
+    // run tween updates
+    (function onFrame() {
+      requestAnimationFrame(onFrame);
+      TWEEN.update();
+    })(); // IIFE
   }
 });

--- a/src/layers/globe.js
+++ b/src/layers/globe.js
@@ -51,7 +51,6 @@ export default Kapsule({
     const globeObj = new THREE.Mesh(globeGeometry, new THREE.MeshPhongMaterial({ color: 0x000000, transparent: true }));
     globeObj.rotation.y = -Math.PI / 2; // face prime meridian along Z axis
     globeObj.__globeObjType = 'globe'; // Add object type
-    globeObj.name = 'three-globe';
 
     // create atmosphere
     let atmosphereObj;
@@ -111,17 +110,14 @@ export default Kapsule({
 
     // Main three object to manipulate
     state.scene = threeObj;
+
+    state.scene.add(state.globeObj); // add globe
+    state.scene.add(state.atmosphereObj); // add atmosphere
+    state.scene.add(state.graticulesObj); // add graticules
   },
 
   update(state, changedProps) {
     const globeMaterial = state.globeObj.material;
-    const addGlobe = () => {
-      if (!state.scene.getObjectByName('three-globe')) {
-        state.scene.add(state.globeObj); // add globe
-        state.scene.add(state.atmosphereObj); // add atmosphere
-        state.scene.add(state.graticulesObj); // add graticules
-      }
-    }
 
     if (changedProps.hasOwnProperty('globeImageUrl')) {
       if (!state.globeImageUrl) {

--- a/src/layers/globe.js
+++ b/src/layers/globe.js
@@ -41,7 +41,8 @@ export default Kapsule({
     globeImageUrl: {},
     bumpImageUrl: {},
     showAtmosphere: { default: true, onChange(showAtmosphere, state) { state.atmosphereObj.visible = !!showAtmosphere }, triggerUpdate: false },
-    showGraticules: { default: false, onChange(showGraticules, state) { state.graticulesObj.visible = !!showGraticules }, triggerUpdate: false }
+    showGraticules: { default: false, onChange(showGraticules, state) { state.graticulesObj.visible = !!showGraticules }, triggerUpdate: false },
+    onGlobeReady: {}
   },
 
   stateInit: () => {
@@ -126,13 +127,13 @@ export default Kapsule({
       if (!state.globeImageUrl) {
         // Black globe if no image
         globeMaterial.color = new THREE.Color(0x000000);
-        addGlobe();
+        state.onGlobeReady()
       } else {
         new THREE.TextureLoader().load(state.globeImageUrl, texture => {
           globeMaterial.map = texture;
           globeMaterial.color = null;
           globeMaterial.needsUpdate = true;
-          addGlobe();
+          state.onGlobeReady()
         });
       }
     }

--- a/src/layers/globe.js
+++ b/src/layers/globe.js
@@ -50,6 +50,7 @@ export default Kapsule({
     const globeObj = new THREE.Mesh(globeGeometry, new THREE.MeshPhongMaterial({ color: 0x000000, transparent: true }));
     globeObj.rotation.y = -Math.PI / 2; // face prime meridian along Z axis
     globeObj.__globeObjType = 'globe'; // Add object type
+    globeObj.name = 'three-globe';
 
     // create atmosphere
     let atmosphereObj;
@@ -109,24 +110,29 @@ export default Kapsule({
 
     // Main three object to manipulate
     state.scene = threeObj;
-
-    state.scene.add(state.globeObj); // add globe
-    state.scene.add(state.atmosphereObj); // add atmosphere
-    state.scene.add(state.graticulesObj); // add graticules
   },
 
   update(state, changedProps) {
     const globeMaterial = state.globeObj.material;
+    const addGlobe = () => {
+      if (!state.scene.getObjectByName('three-globe')) {
+        state.scene.add(state.globeObj); // add globe
+        state.scene.add(state.atmosphereObj); // add atmosphere
+        state.scene.add(state.graticulesObj); // add graticules
+      }
+    }
 
     if (changedProps.hasOwnProperty('globeImageUrl')) {
       if (!state.globeImageUrl) {
         // Black globe if no image
         globeMaterial.color = new THREE.Color(0x000000);
+        addGlobe();
       } else {
         new THREE.TextureLoader().load(state.globeImageUrl, texture => {
           globeMaterial.map = texture;
           globeMaterial.color = null;
           globeMaterial.needsUpdate = true;
+          addGlobe();
         });
       }
     }


### PR DESCRIPTION
I would like to be able to prevent the globe from rendering until the globe texture is loaded. In other words, I don't want the default black globe to show while the globe texture image is loading.

One way to achieve this is by doing exposing the globe's texture in the api and then using it like this:
```
new THREE.TextureLoader().load('/map.jpg', globeTexture => {
  this.scene.add( new ThreeGlobe().globeTexture(globeTexture) )
})
```
this way the globe renders when the texture is ready.

There's probably a few other ways to accomplish this, and this change would also need some documentation changes, but I wanted to get your thoughts before proceeding any further.