### PR TITLE
Avoid infinite loop when tileCurvatureResolution is set to 0

### DIFF
--- a/src/layers/tiles.js
+++ b/src/layers/tiles.js
@@ -80,8 +80,8 @@ export default Kapsule({
 
           obj.geometry = new THREE.SphereBufferGeometry(
             GLOBE_RADIUS * (1 + alt),
-            Math.ceil(width / curvatureResolution),
-            Math.ceil(height / curvatureResolution),
+            Math.ceil(width / (curvatureResolution || -1)),
+            Math.ceil(height / (curvatureResolution || -1)),
             deg2Rad(90 - width / 2) + (useGlobeProjection ? rotLng : 0),
             deg2Rad(width),
             deg2Rad(90 - height / 2) + (useGlobeProjection ? rotLat : 0),


### PR DESCRIPTION
Setting `tileCurvatureResolution` to `0` currently results in an infinite loop, that hangs the browser.  A very small value (e.g. `0.0001`) could also lead to that, but it's somewhat fair since that's just the browser/GPU not being able to handle so many computations/polygons.  `Infinity` is a different story however, that happens due to division by zero.