### PR TITLE
Fix division by 0 in arcs layer curve calculation

### DIFF
--- a/src/layers/arcs.js
+++ b/src/layers/arcs.js
@@ -289,7 +289,7 @@ export default Kapsule({
           : t => new THREE.Vector3().addVectors(
             startVec.clone().multiplyScalar(Math.sin( (1 - t) * angle)),
             endVec.clone().multiplyScalar(Math.sin(t  * angle))
-          ).divideScalar(Math.sin(angle));
+          ).divideScalar(Math.sin(angle) || 1);
 
         const sphereArc = new THREE.Curve();
         sphereArc.getPoint = getGreatCirclePoint;


### PR DESCRIPTION
**tldr; encountered a divide by Zero condition, thought I'd share...**

Set off on a bit of a journey recently tracking down, what I thought was, a memory leak using the React Bindings repo "react-globe.gl". In my application, I am adding and removing arc layer data in real time to visualize the random network model of an active cryptocurrency network. I found that upon removing arc data, *sometimes*, I would get errors in the console:
![Capture](https://user-images.githubusercontent.com/1339115/161169884-87a28f75-fc2c-4e8b-a0b5-550bfd9ac3d0.PNG)
(I can hastily reproduce this by going to <https://codesandbox.io/s/react-globe-gl-arcs-with-rings-n2mxh0?file=/src/App.tsx> and changing the timeout value on line 86 of App.tsx to a much lower number)

I thought that perhaps this error was halting a cleanup routine. Tracked down the error to an intermittent divide by Zero condition, fixed the condition, the error disappeared but the memory consumption continued.

I don't know why I didn't try it in the first place, but after trying almost everything I could think of, I switched from Firefox to Chromium and my RAMs were no longer excessively allocated to the browser.