### PR TITLE
fix strange onFrame issue when compiled in Vercel

### DIFF
--- a/src/globe-kapsule.js
+++ b/src/globe-kapsule.js
@@ -358,11 +358,13 @@ export default Kapsule({
       ? state.globeLayer.onReady(initGlobe)
       : initGlobe();
 
-    // run tween updates
-    (function onFrame() {
+    const onFrame = function () {
       requestAnimationFrame(onFrame);
       TWEEN.update();
-    })(); // IIFE
+    }
+
+    // run tween updates
+    onFrame(); // IIFE
   },
 
   update(state) {}


### PR DESCRIPTION
for some reason the name "onFrame" is not persisted when compiled in Vercel; variable-referencing the "onFrame" function should fix this. 