### PR TITLE
Add class names to CSS2DObjects

### DIFF
--- a/src/layers/htmlElements.js
+++ b/src/layers/htmlElements.js
@@ -31,10 +31,13 @@ export default Kapsule({
 
   methods: {
     updateObjVisibility(state, obj) {
-      // default to all if no obj specified
+      // Default to all if no obj specified
       const objs = obj ? [obj] : state.htmlElementsData.map(d => d.__threeObj).filter(d => d);
       // Hide elements on the far side of the globe
-      objs.forEach(obj => (obj.visible = !state.isBehindGlobe || !state.isBehindGlobe(obj.position)));
+      objs.forEach(obj => {
+        (obj.visible = !state.isBehindGlobe || !state.isBehindGlobe(obj.position))
+        obj.element.classList.toggle('visible', obj.visible );
+      });
     }
   },
 
@@ -60,6 +63,7 @@ export default Kapsule({
         let elem = elemAccessor(d);
 
         const obj = new THREE.CSS2DObject(elem);
+        obj.element.classList.add('css-object');
 
         obj.__globeObjType = 'html'; // Add object type
 


### PR DESCRIPTION
### **Description**

**The problem:** CSS2DObjects are currently hidden/shown using `display: none` with no alternatives for custom css animations.

There's an open pr to [three.js](https://github.com/mrdoob/three.js/pull/25088) to update CSS2DRenderer, however it was suggested to make this update to the application level instead.

**The solution:** Adding a class attribute will allow developers to override with css transitions if necessary.

```
.css-object {
  display: block !important;
  pointer-events: none;
  opacity: 0;
  transition: 500ms opacity;

  &.visible {
    opacity: 1;
    pointer-events: all;
  }
}
```



