### PR TITLE
Fix ignored HTML transition durations

### DIFF
--- a/src/layers/htmlElements.js
+++ b/src/layers/htmlElements.js
@@ -84,7 +84,7 @@ export default Kapsule({
         } else {
           // animate
           new TWEEN.Tween(obj.__currentTargetD)
-            .to(targetD, state.pointsTransitionDuration)
+            .to(targetD, state.htmlTransitionDuration)
             .easing(TWEEN.Easing.Quadratic.InOut)
             .onUpdate(applyUpdate)
             .start();


### PR DESCRIPTION
Have been attempting to implement nice moving htmlElements and noticed the transition time settings were being ignored entirely – turns out it was a pretty simple fix.