### PR TITLE
Add projection type to description of image functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ new ThreeGlobe({ configOptions })
 
 | Method | Description | Default |
 | --- | --- | :--: |
-| <b>globeImageUrl</b>([<i>url</i>]) | Getter/setter for the URL of the image used in the material that wraps the globe. If no image is provided, the globe is represented as a black sphere. | `null` |
-| <b>bumpImageUrl</b>([<i>url</i>]) | Getter/setter for the URL of the image used to create a [bump map](https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.bumpMap) in the material, to represent the globe's terrain. | `null` |
+| <b>globeImageUrl</b>([<i>url</i>]) | Getter/setter for the URL of the equirectangular projection image used in the material that wraps the globe. If no image is provided, the globe is represented as a black sphere. | `null` |
+| <b>bumpImageUrl</b>([<i>url</i>]) | Getter/setter for the URL of the equirectangular projection image used to create a [bump map](https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.bumpMap) in the material, to represent the globe's terrain. | `null` |
 | <b>showGlobe</b>([<i>boolean</i>]) | Getter/setter for whether to show the globe surface itself. | `true` |
 | <b>showGraticules</b>([<i>boolean</i>]) | Getter/setter for whether to show a graticule grid demarking latitude and longitude lines at every 10 degrees. | `false` |
 | <b>showAtmosphere</b>([<i>boolean</i>]) | Getter/setter for whether to show a bright halo surrounding the globe, representing the atmosphere. | `true` |


### PR DESCRIPTION
I spent a lot of time in finding out the projection type of the Earth images and finding alternative versions of it. Only when somebody told me that this was "**equirectangular projection**", I was able to find the resources I needed. That is the reason for this pull request, which adds the projection type to the description of the image functions in the README.