### PR TITLE
fix(Arcs Layer): dashed line shaders extra calculation Three.js depth

### DIFF
--- a/src/utils/shaders.js
+++ b/src/utils/shaders.js
@@ -28,7 +28,7 @@ export const dashedLineShaders = () => ({
     }
   `,
   fragmentShader: `
-    ${ShaderChunk.logdepthbuf_fragment}
+    ${ShaderChunk.logdepthbuf_pars_fragment}
     uniform float dashOffset; 
     uniform float dashSize;
     uniform float gapSize; 


### PR DESCRIPTION
I added `vFragDepth` and `vIsPerspective` variables provided by Three.js to the Dashed Line Shaders shader to solve the bug in issue # 108 regarding the depth of `Arc layers`

Please help test if this code is qualified. If there are any extension bugs, please let me know. I am glad to have contributed to it!